### PR TITLE
Remove illuminate/collections dependency causing conflicts with later versions

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Configure PHP environment
         uses: shivammathur/setup-php@v2
         with:

--- a/.github/workflows/tests-php.yml
+++ b/.github/workflows/tests-php.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1000
           submodules: recursive
@@ -18,26 +18,13 @@ jobs:
       # Checkout slic
       # ------------------------------------------------------------------------------
       - name: Checkout slic
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: stellarwp/slic
           ref: main
           path: slic
           fetch-depth: 1
-      # ------------------------------------------------------------------------------
-      # Prepare our composer cache directory
-      # ------------------------------------------------------------------------------
-      - name: Get Composer Cache Directory
-        id: get-composer-cache-dir
-        run: |
-          echo "::set-output name=dir::$(composer config cache-files-dir)"
-      - uses: actions/cache@v2
-        id: composer-cache
-        with:
-          path: ${{ steps.get-composer-cache-dir.outputs.dir }}
-          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-composer-
+
       # ------------------------------------------------------------------------------
       # Initialize slic
       # ------------------------------------------------------------------------------

--- a/composer.json
+++ b/composer.json
@@ -27,9 +27,6 @@
     }
   ],
   "minimum-stability": "stable",
-  "require": {
-    "illuminate/collections": "^8.0"
-  },
   "require-dev": {
     "lucatume/wp-browser": "^3.5 || ^4.0",
     "szepeviktor/phpstan-wordpress": "^1.1",

--- a/docs/Home.md
+++ b/docs/Home.md
@@ -23,4 +23,4 @@ This is an automatically generated documentation for **Documentation**.
 
 
 ***
-> Automatically generated on 2025-01-17
+> Automatically generated on 2025-02-07

--- a/docs/classes/StellarWP/Arrays/Arr.md
+++ b/docs/classes/StellarWP/Arrays/Arr.md
@@ -357,7 +357,7 @@ public static except(array $array, array|string|int|float $keys): array
 Determine if the given key exists in the provided array.
 
 ```php
-public static exists(\ArrayAccess|\Illuminate\Support\Enumerable|array $array, string|int|float $key): bool
+public static exists(\ArrayAccess|array $array, string|int|float $key): bool
 ```
 
 
@@ -371,7 +371,7 @@ public static exists(\ArrayAccess|\Illuminate\Support\Enumerable|array $array, s
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `$array` | **\ArrayAccess&#124;\Illuminate\Support\Enumerable&#124;array** |  |
+| `$array` | **\ArrayAccess&#124;array** |  |
 | `$key` | **string&#124;int&#124;float** |  |
 
 
@@ -1691,4 +1691,4 @@ whose keys exist in every provided array, recursively.
 
 
 ***
-> Automatically generated on 2025-01-17
+> Automatically generated on 2025-02-07

--- a/src/Arrays/Arr.php
+++ b/src/Arrays/Arr.php
@@ -3,6 +3,7 @@
 namespace StellarWP\Arrays;
 
 use ArrayAccess;
+use Closure;
 use InvalidArgumentException;
 
 /**
@@ -1457,5 +1458,19 @@ class Arr {
 		}
 
 		return $array;
+	}
+
+	/**
+	 * Return the default value of the given value.
+	 *
+	 * @template TValue
+	 * @template TArgs
+	 *
+	 * @param  TValue|\Closure(TArgs): TValue  $value
+	 * @param  TArgs  ...$args
+	 * @return TValue
+	 */
+	private static function value( $value, ...$args ) {
+		return $value instanceof Closure ? $value( ...$args ) : $value;
 	}
 }

--- a/src/Arrays/Arr.php
+++ b/src/Arrays/Arr.php
@@ -3,7 +3,6 @@
 namespace StellarWP\Arrays;
 
 use ArrayAccess;
-use Illuminate\Support\Enumerable;
 use InvalidArgumentException;
 
 /**
@@ -302,7 +301,7 @@ class Arr {
 	/**
 	 * Determine if the given key exists in the provided array.
 	 *
-	 * @param \ArrayAccess|Enumerable|array $array
+	 * @param \ArrayAccess|array $array
 	 * @param string|int|float   $key
 	 *
 	 * @return bool

--- a/src/Arrays/Arr.php
+++ b/src/Arrays/Arr.php
@@ -348,7 +348,7 @@ class Arr {
 	public static function first( $array, callable $callback = null, $default = null ) {
 		if ( is_null( $callback ) ) {
 			if ( empty( $array ) ) {
-				return value( $default );
+				return self::value( $default );
 			}
 
 			foreach ( $array as $item ) {
@@ -362,7 +362,7 @@ class Arr {
 			}
 		}
 
-		return value( $default );
+		return self::value( $default );
 	}
 
 	/**
@@ -709,7 +709,7 @@ class Arr {
 	 */
 	public static function last( $array, callable $callback = null, $default = null ) {
 		if ( is_null( $callback ) ) {
-			return empty( $array ) ? value( $default ) : end( $array );
+			return empty( $array ) ? self::value( $default ) : end( $array );
 		}
 
 		return static::first( array_reverse( $array, true ), $callback, $default );


### PR DESCRIPTION
### Main Changes

- Removes the `illuminate/collections` dependency to avoid conflicts and given we were only using the [value function](https://github.com/illuminate/collections/blob/master/helpers.php#L234-L237) of that package, I just added it as a private static method instead.
- Update GitHub workflows to their latest versions.